### PR TITLE
Add export template for org-mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,46 @@
+# What's this? #
+
 Doit.im export of tasks (because Doit.im still does not support it at the time of writing).
 
-In Chrome: open up the Doit.im website.
+# How to? #
 
-(optional) Make a custom filter that will show you all tasks.
+## when exporting to todoist ##
 
-Open up a list view for your custom filter (works with any list view really)
+Do the following In Chrome:
 
-Open up the Developer Console (option+command+i on the Mac, Ctrl-Shift-i on windows).
+- open up the Doit.im website.
 
-Paste javascript code in js-files into the console and hit enter. The task-lines will now be in the clipboard (if successful)
+- (optional) Make a custom filter that will show you all tasks.
 
-Go into your favorite text editor and paste, but save file as UTF-8 (in case of special language chars)
+- Open up a list view for your custom filter (works with any list view really)
 
+- Open up the Developer Console (option+command+i on the Mac, Ctrl-Shift-i on windows).
 
-The script exports: Task name, Priority, tags, context, Project, and notes.
-It does not export subtasks. 
+- Paste javascript code in js-files into the console and hit enter. The task-lines will now be in the clipboard (if successful)
+
+- Go into your favorite text editor and paste, but save file as UTF-8 (in case of special language chars)
+
+The script exports: **Task name, Priority, tags, context, Project, and notes.**
+It does *not* export subtasks. 
+
+## Export to org-mode ##
+
+Using the
+[recommanded organization method](https://github.com/ttimasdf/org-gtd-feature-lists/blob/master/7-project_management.org),
+
+- open each of your goals view (if you are premium, use custom filters
+is good as well) and run
+[projects export](https://github.com/ttimasdf/doitimExport/blob/master/doitExport_org-projects.js)
+and paste them into a `.org` file.
+
+- open each project and run
+  [items export](https://github.com/ttimasdf/doitimExport/blob/master/doitExport_org-items.js)
+  to paste todo items into each projects.
+- If you have any subtasks, copy all lines of subtasks from the task
+  view and paste into the org file, placing the cursor at the beginning.
+- Invoke `<f3> - SPC C-u C-c C-c C-n C-a <f4>` to define a macro for adding [checkboxs](https://github.com/ttimasdf/org-gtd-feature-lists/blob/master/2-checkbox.org).
+- Press `<f4>` as many times as needed to add checkbox for each subtask.
+- (Optional) add a counter in the task title like `[1/3]` or `[33%]`, details at [here](https://github.com/ttimasdf/org-gtd-feature-lists/blob/master/2-checkbox.org#the-count-of-checkbox-of-the-same-grade-15)
 
 Links for info on Chrome Console developing:
 http://stackoverflow.com/questions/2934787/view-list-of-all-javascript-variables-in-google-chrome-console

--- a/doitExport_org-items.js
+++ b/doitExport_org-items.js
@@ -1,0 +1,69 @@
+function contextLookup(ctxId) {
+	var arr = Doit.contexts;
+    for(var i=0; i< arr.length; i++) {
+        if (arr[i].uuid == ctxId) return arr[i].name;
+    }
+    return "missing";
+}
+
+function projLookup(projId) {
+	var projects = Doit.projects;
+    for(var i=0; i< projects.length; i++) {
+        if (projects[i].uuid == projId) return projects[i].name;
+    }
+    return "missing";
+}
+
+var tagSeparator = ":";
+var allTaskLines = "";
+var noTasks = TASKS.length;
+for (var i = 0; i < noTasks; i++) {
+  var task = TASKS[i]; 
+  // var thisTaskLine = task.title; 
+  var thisTaskLine = "** " + ( (task.attribute == "noplan")?
+                               "WAITING":
+                               ( (task.attribute == "next")?
+                                 "NEXT":
+                                 ( (task.attribute == "plan")?
+                                   "SCHEDULED":
+                                   " "
+                                 )
+                               )
+                             );
+  thisTaskLine = thisTaskLine + ( (task.priority)?
+                                  (" [#" + (
+                                    (task.priority-1)?
+                                      (task.priority-2)?
+                                      (task.priority-3)?
+                                      "fuck?":"A":"B":"C")
+                                   + "] ") 
+                                  :" " );
+  // WRONG: thisTaskLine = thisTaskLine + (task.priority-1 == 0)?(task.priority-2==0)?(task.priority-3==0)?"":"C":"B":"A" + "ok"
+
+  thisTaskLine = thisTaskLine + task.title + "     ";
+  // var thisTaskLine = thisTaskLine +" !p"+task.priority;
+
+
+  var tags = task.tags;
+  var thisTaskLine = thisTaskLine + tagSeparator + ((contextLookup(task.context) == "missing")?
+                                                    "":
+                                                    ("@"+contextLookup(task.context) + tagSeparator));
+  
+  if (!(typeof tags === 'undefined')) {
+    var noTags = task.tags.length;
+    for (var j = 0; j < noTags; j++) {
+      thisTaskLine =  thisTaskLine + tags[j] + tagSeparator;
+    }
+    // thisTaskLine = thisTaskLine + tagSeparator;
+  }
+  thisTaskLine = thisTaskLine + '\n';
+
+  if (!(typeof task.notes === 'undefined')) {
+    // replace new lines in notes with '/n', because I want one task on each line
+    // var notes = task.notes.replace(/[\r\n]/g, "/n").replace(/[\n]/g, "/n");
+    var thisTaskLine = thisTaskLine + task.notes + "\n"; 
+  }
+  allTaskLines = allTaskLines + thisTaskLine + "\n\n";
+}
+console.log(allTaskLines);
+copy(allTaskLines);

--- a/doitExport_org-projects.js
+++ b/doitExport_org-projects.js
@@ -1,0 +1,69 @@
+function contextLookup(ctxId) {
+	var arr = Doit.contexts;
+    for(var i=0; i< arr.length; i++) {
+        if (arr[i].uuid == ctxId) return arr[i].name;
+    }
+    return "missing";
+}
+
+function projLookup(projId) {
+	var projects = Doit.projects;
+    for(var i=0; i< projects.length; i++) {
+        if (projects[i].uuid == projId) return projects[i].name;
+    }
+    return "missing";
+}
+
+var tagSeparator = ":";
+var allTaskLines = "";
+var noTasks = TASKS.length;
+for (var i = 0; i < noTasks; i++) {
+  var task = TASKS[i]; 
+  // var thisTaskLine = task.title; 
+  var thisTaskLine = "\* PROJECT ";
+  // var thisTaskLine = thisTaskLine +" !p"+task.priority;
+  // thisTaskLine = thisTaskLine + ( (task.priority)?
+  //                                 (" [#" + (
+  //                                   (task.priority-1)?
+  //                                     (task.priority-2)?
+  //                                     (task.priority-3)?
+  //                                     "fuck?":"A":"B":"C")
+  //                                  + "] ") 
+  //                                 :" " );
+  // WRONG: thisTaskLine = thisTaskLine + (task.priority-1 == 0)?(task.priority-2==0)?(task.priority-3==0)?"":"C":"B":"A" + "ok"
+
+  // thisTaskLine = thisTaskLine + ( (task.attribute == "noplan")?
+  //                                 "WAITING ":
+  //                                 ( (task.attribute == "next")?
+  //                                   "NEXT ":
+  //                                   ( (task.attribute == "plan")?
+  //                                     "SCHEDULED ":
+  //                                     " "
+  //                                   )
+  //                                 )
+  //                               );
+  thisTaskLine = thisTaskLine + task.title + "     ";
+
+  var tags = task.tags;
+  var thisTaskLine = thisTaskLine + tagSeparator + ((contextLookup(task.context) == "missing")?
+                                                    "":
+                                                    ("@"+contextLookup(task.context) + tagSeparator));
+  
+  if (!(typeof tags === 'undefined')) {
+    var noTags = task.tags.length;
+    for (var j = 0; j < noTags; j++) {
+      thisTaskLine =  thisTaskLine + tags[j] + tagSeparator;
+    }
+    // thisTaskLine = thisTaskLine + tagSeparator;
+  }
+  thisTaskLine = thisTaskLine + '\n';
+
+  if (!(typeof task.notes === 'undefined')) {
+    // replace new lines in notes with '/n', because I want one task on each line
+    // var notes = task.notes.replace(/[\r\n]/g, "/n").replace(/[\n]/g, "/n");
+    var thisTaskLine = thisTaskLine + task.notes + "\n"; 
+  }
+  allTaskLines = allTaskLines + thisTaskLine + "\n\n";
+}
+console.log(allTaskLines);
+copy(allTaskLines);


### PR DESCRIPTION
Personally migrating from http://doit.im to Emacs [org-mode](http://orgmode.org). Modified to suit my need, maybe of help to others :-)

Consists of two parts, `doitExport_org-projects.js` and `doitExport_org-items.js`, which respectively convert project titles and tasks. Detailed how-to in the README.

Good day.~
